### PR TITLE
fix(script): Make AutomaticRun.sh robust with error handling

### DIFF
--- a/AutomaticRun.sh
+++ b/AutomaticRun.sh
@@ -3,58 +3,73 @@
 MODEL=("ItemKNN" "PFCN_DMF" "PFCN_biasedMF" "NFCF" "FOCF" "FairGo_PMF" "FairGo_GCN" "PFCN_PMF" "NGCF" "SGL" "LightGCN" "DMF" "NeuMF" "NNCF" "DGCF")
 CONFIG=("ML,ml-1M" "LFM,LastFM-100K" "BR,BookRec-100K")
 
-# LOG_DIR is the directory you'd like to save the results, e.g:
-LOG_DIR="~/work/code-results/"
+LOG_DIR="$HOME/work/code-results/"
+mkdir -p "$LOG_DIR"
 
 for config in ${CONFIG[@]}; do
     IFS=',' read -r -a config_arr <<< "$config"
     
     for model in ${MODEL[@]}; do
-        output_file="${LOG_DIR}Run_$(date +'%H%M')_${model}-${config_arr[1]}.log"
-        # command="python3 resume_run_recbole.py --model=${model} --config=Configuration${config_arr[0]}.yaml --dataset=${config_arr[1]} > ${output_file} 2>&1"
-        if [[ "$@" == *-r* ]] || [[ "$@" == *--resume* ]]; then
-            command="python3 resume_run_recbole.py --model=${model} --config=Configuration${config_arr[0]}.yaml --dataset=${config_arr[1]} > ${output_file} 2>&1"
-            echo "# NOTE: running in resume mode, only evaluating"
-        else
-            command="python3 run_recbole.py --model=${model} --config=Configuration${config_arr[0]}.yaml --dataset=${config_arr[1]} > ${output_file} 2>&1"
-            echo "# NOTE: running in FULL training mode."
-        fi
+        # --- Define Log File Names ---
+        timestamp=$(date +'%H%M')
+        base_log_name="${LOG_DIR}Run_${timestamp}_${model}-${config_arr[1]}"
+        
+        # Final log file for SUCCESSFUL runs
+        success_log_file="${base_log_name}.log"
+        # Log file for FAILED runs
+        error_log_file="${base_log_name}.ERROR.log"
+        # Temporary file to capture all output
+        temp_log_file="${base_log_name}.temp.log"
+
         # Start timer
         start=$(date +%s)
         
-        # Run the script in the background
-        eval $command &
+        if [[ "$@" == *-r* ]] || [[ "$@" == *--resume* ]]; then
+            echo "# NOTE: running in resume mode, only evaluating"
+            python3 resume_run_recbole.py --model=${model} --config=Configuration${config_arr[0]}.yaml --dataset=${config_arr[1]} > "${temp_log_file}" 2>&1 &
+        else
+            echo "# NOTE: running in FULL training mode."
+            python3 run_recbole.py --model=${model} --config=Configuration${config_arr[0]}.yaml --dataset=${config_arr[1]} > "${temp_log_file}" 2>&1 &
+        fi
         
-        # Get the process ID of the background task
         pid=$!
         
-        # Display progress dots
-        echo -n "Running $model-$config_arr[1]..."
+        echo -n "Running $model-${config_arr[1]}..."
         
-        # Check the status of the process every second
         while ps -p $pid > /dev/null; do
             echo -n "."
             sleep 1
         done
         
-        # Calculate the duration
+        wait $pid
+        exit_code=$?
+        
+        # Calculate duration
         end=$(date +%s)
         duration=$((end - start))
+        time_taken=$(printf "%02d:%02d" $((duration / 60)) $((duration % 60)))
         
-        # Convert duration to MM:SS format
-        minutes=$((duration / 60))
-        seconds=$((duration % 60))
-        time_taken=$(printf "%02d:%02d" $minutes $seconds)
+        echo "" # Newline after dots
         
-        # Output time taken to run the code
-        echo ""
-        echo "Code with $output_file took $time_taken to run."
+        # --- User-Friendly Log Handling ---
+        # Check if the command failed OR finished suspiciously fast (e.g., < 5 seconds)
+        if [ $exit_code -ne 0 ] || [ $duration -lt 5 ]; then
+            # FAILURE CASE
+            echo "!! JOB FAILED ($time_taken). Full error log saved to:"
+            echo "   ${error_log_file}"
+            # Move the temp log to the final ERROR log location
+            mv "${temp_log_file}" "${error_log_file}"
+        else
+            # SUCCESS CASE
+            echo "Job finished successfully ($time_taken)."
+            # Create the truncated 20-line log from the temp file
+            tail -n 20 "${temp_log_file}" > "${success_log_file}"
+            # Clean up the full temporary log
+            rm "${temp_log_file}"
+            echo "Results saved to: ${success_log_file}"
+        fi
         
-        # Save only the last 20 lines of the log file
-        command2="tail -n 20 $output_file > ${output_file}.tmp && mv ${output_file}.tmp $output_file"
-        eval $command2 &
-        
-        # Wait for 1 second before starting the next iteration
+        echo "------------------------------------------------------"
         sleep 1
     done
 done


### PR DESCRIPTION
**Body:**

This PR fixes a issue where the `AutomaticRun.sh` script would fail silently.

Fixes #13

### Before

The script piped all output directly to `tail -n 20`. If a Python job crashed instantly (e.g., `ModuleNotFoundError`), the script would still "succeed" in 1 second and produce an empty or useless log file, making it impossible to debug.

### After

This new version implements robust error checking:

1.  It saves the **full log** to a temporary file.
2.  It checks the Python script's **exit code** and **run duration**.
3.  **On Success:** It creates the clean, 20-line log file as originally requested.
4.  **On Failure:** It saves the *entire* error log to a clearly-named `.ERROR.log` file, telling the user exactly what went wrong.

This fulfills the original requirement (a 20-line log) while also making the script stable and easy to debug.